### PR TITLE
AB#71 Add attributes property to NFT node

### DIFF
--- a/Nodes/Attribute.cs
+++ b/Nodes/Attribute.cs
@@ -1,0 +1,13 @@
+using Newtonsoft.Json;
+
+namespace TAG.Nodes
+{
+    public class Attribute
+    {
+        [JsonProperty("trait_type")]
+        public string TraitType { get; set; } = null!;
+
+        [JsonProperty("value")]
+        public string Value { get; set; } = null!;
+    }
+}

--- a/Nodes/NFTNode.cs
+++ b/Nodes/NFTNode.cs
@@ -1,3 +1,4 @@
+using SYSTEM_JSON = System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace TAG.Nodes
@@ -16,7 +17,7 @@ namespace TAG.Nodes
         [JsonProperty("description")]
         public string? Description { get; set; }
 
-        [JsonIgnore]
+        [SYSTEM_JSON.JsonIgnore]
         [JsonProperty("attributes")]
         public string? AttributesString { get; set; }
 

--- a/Nodes/NFTNode.cs
+++ b/Nodes/NFTNode.cs
@@ -15,5 +15,22 @@ namespace TAG.Nodes
 
         [JsonProperty("description")]
         public string? Description { get; set; }
+
+        [JsonIgnore]
+        [JsonProperty("attributes")]
+        public string? AttributesString { get; set; }
+
+        public IEnumerable<Attribute> Attributes
+        {
+            get
+            {
+                if (AttributesString == null)
+                {
+                    return new List<Attribute>();
+                }
+
+                return JsonConvert.DeserializeObject<List<Attribute>>(AttributesString) ?? new List<Attribute>();
+            }
+        }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -34,7 +34,7 @@ namespace TAG
             // Add services to the container.
             builder.Services.AddScoped<ITransactionService, TransactionService>();
 
-            builder.Services.AddControllers();
+            builder.Services.AddControllers().AddNewtonsoftJson();
 
             // Neo4j
             var neo4jUri = builder.Configuration["Neo4j:Uri"];

--- a/Program.cs
+++ b/Program.cs
@@ -34,7 +34,7 @@ namespace TAG
             // Add services to the container.
             builder.Services.AddScoped<ITransactionService, TransactionService>();
 
-            builder.Services.AddControllers().AddNewtonsoftJson();
+            builder.Services.AddControllers();
 
             // Neo4j
             var neo4jUri = builder.Configuration["Neo4j:Uri"];

--- a/TAG.csproj
+++ b/TAG.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.12" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.13" />
     <PackageReference Include="Neo4jClient" Version="5.1.11" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>

--- a/TAG.csproj
+++ b/TAG.csproj
@@ -11,13 +11,14 @@
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.12" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.13" />
     <PackageReference Include="Neo4jClient" Version="5.1.11" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 
   <!-- set HUSKY to 0 in CI/CD disable this -->
   <Target Name="husky" BeforeTargets="Restore;CollectPackageReferences" Condition="'$(HUSKY)' != 0">
-    <Exec Command="dotnet tool restore"  StandardOutputImportance="Low" StandardErrorImportance="High"/>
+    <Exec Command="dotnet tool restore" StandardOutputImportance="Low" StandardErrorImportance="High" />
     <Exec Command="dotnet husky install" StandardOutputImportance="Low" StandardErrorImportance="High" WorkingDirectory="$(MSBuildProjectDirectory)" />
   </Target>
 


### PR DESCRIPTION
Added the attributes property to NFT node, which was added to database. 

Note: When ignoring property, we have to use System.Text.Json.Serialization, which is the default serialization for the controllers